### PR TITLE
Migrate from OSSRH to Central Portal

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -16,24 +16,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '21'
         distribution: 'temurin'
         cache: 'maven'
-        server-id: ossrh
+        server-id: central
         server-username: MAVEN_USERNAME # env variable which is set in deploy step
         server-password: MAVEN_PASSWORD # env variable which is set in deploy step
-        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # PGP secret key which will be imported into keyring 
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # PGP secret key which will be imported into keyring
         gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable which is set in deploy step
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
     - name: Publish to Maven Central
-      run: mvn -B deploy -D env=ci -P release
+      run: mvn -B deploy -D env=ci
       env:
-        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .settings/
 .project
 .classpath
+bin/
 target/
 pom.xml.tag
 pom.xml.releaseBackup

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -71,6 +70,15 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.14.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -128,20 +136,22 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.1.1</version>
         <configuration>
+          <releaseProfiles>release</releaseProfiles>
           <tagNameFormat>v@{project.version}</tagNameFormat>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <autoPublish>true</autoPublish>
+          <checksums>all</checksums>
+          <publishingServerId>central</publishingServerId>
+          <waitUntil>published</waitUntil>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
com.festo.aas namespace has been migrated to Central Portal (see [FAQ](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/)).

This PR updates project metadata and Github actions to publish via Central.